### PR TITLE
feat: get title by 'xprop' directly, add support for webstorm, wechat, etc. 使用xprop直接获取窗口class，添加应用支持

### DIFF
--- a/src/get_media.rs
+++ b/src/get_media.rs
@@ -10,8 +10,7 @@ use dbus::blocking::stdintf::org_freedesktop_dbus::Properties;
 use dbus::blocking::Connection;
 use dbus::blocking::Proxy;
 
-#[derive(Clone, PartialEq)]
-#[derive(Default)]
+#[derive(Clone, PartialEq, Default, Debug)]
 pub struct MediaMetadata {
     pub title: Option<String>,
     pub artist: Option<String>,
@@ -19,9 +18,10 @@ pub struct MediaMetadata {
 
 
 mod constants {
-    pub const MEDIA_PLAYER_IDENTIFIERS: [&str; 2] = [
+    pub const MEDIA_PLAYER_IDENTIFIERS: [&str; 3] = [
         "org.mpris.MediaPlayer2.yesplaymusic",
         "org.mpris.MediaPlayer2.netease-cloud-music",
+        "org.mpris.MediaPlayer2.spotify"
     ];
     pub const MPRIS_PLAYER_INTERFACE: &str = "org.mpris.MediaPlayer2.Player";
     pub const METADATA_PROPERTY: &str = "Metadata";


### PR DESCRIPTION
### Description
- Updated `get_active_window_process_and_title` function to use `xprop` for fetching the active window ID and class name.
- Add support for webstorm, wechat, etc.
- 更新了get_active_window_process_and_title函数，使用xprop获取活动窗口的ID和类名。
- 增加了对WebStorm、WeChat等应用程序窗口标题的支持。

### Additional context
Tested on Archlinux (6.12.6-arch1-1) + KDE (6.2.4) with Wayland. Successfully retrieved window titles for applications like Code, WebStorm, WeChat, QQ, Chrome, YesPlayMusic, and Typora. However, there are no solutions for Konsole, Telegram, and KMail. The PR includes support for both English and Chinese titles.
在Archlinux（6.12.6-arch1-1）+KDE（6.2.4）且Wayland下测试通过，可以获取相关标题，但是终端（Konsole）没有解决方案，telegram和kmail也无法获取，已经测试成功的有code，webstorm，wechat，qq，chrome
，yesplaymusic，typora